### PR TITLE
infer dimension from geometry

### DIFF
--- a/Wrappers/Python/ccpi/astra/utils/convert_geometry_to_astra.py
+++ b/Wrappers/Python/ccpi/astra/utils/convert_geometry_to_astra.py
@@ -12,12 +12,12 @@ def convert_geometry_to_astra(volume_geometry, sinogram_geometry):
     # determine if the geometry is 2D or 3D
     horiz = sinogram_geometry.pixel_num_h
     vert  = sinogram_geometry.pixel_num_v
-    if vert > 1:
+    if vert >= 1:
         dimension = '3D'
-    elif vert == 1:
+    elif vert == 0:
         dimension = '2D'
     else:
-        raise ValueError('Number of pixels at detector on the vertical axis must be > 1. Got {}'.format(vert))
+        raise ValueError('Number of pixels at detector on the vertical axis must be >= 0. Got {}'.format(vert))
     
     if dimension == '2D':
         vol_geom = astra.create_vol_geom(volume_geometry.voxel_num_x, 

--- a/Wrappers/Python/ccpi/astra/utils/convert_geometry_to_astra.py
+++ b/Wrappers/Python/ccpi/astra/utils/convert_geometry_to_astra.py
@@ -2,8 +2,24 @@ import astra
 import numpy as np
 
 def convert_geometry_to_astra(volume_geometry, sinogram_geometry):
-    # Set up ASTRA Volume and projection geometry, not stored
-    if sinogram_geometry.dimension == '2D':
+    '''Set up ASTRA Volume and projection geometry, not stored
+
+       :param volume_geometry: ccpi.framework.ImageGeometry
+       :param sinogram_geometry: ccpi.framework.AcquisitionGeometry
+       
+       :returns ASTRA volume and sinogram geometry'''
+
+    # determine if the geometry is 2D or 3D
+    horiz = sinogram_geometry.pixel_num_h
+    vert  = sinogram_geometry.pixel_num_v
+    if vert > 1:
+        dimension = '3D'
+    elif vert == 1:
+        dimension = '2D'
+    else:
+        raise ValueError('Number of pixels at detector on the vertical axis must be > 1. Got {}'.format(vert))
+    
+    if dimension == '2D':
         vol_geom = astra.create_vol_geom(volume_geometry.voxel_num_x, 
                                          volume_geometry.voxel_num_y, 
                                          volume_geometry.get_min_x(), 
@@ -26,7 +42,7 @@ def convert_geometry_to_astra(volume_geometry, sinogram_geometry):
         else:
             NotImplemented
             
-    elif sinogram_geometry.dimension == '3D':
+    elif dimension == '3D':
         vol_geom = astra.create_vol_geom(volume_geometry.voxel_num_x, 
                                          volume_geometry.voxel_num_y, 
                                          volume_geometry.voxel_num_z, 


### PR DESCRIPTION
closes #41

```python
from ccpi.astra.utils import *
from ccpi.framework import *
import numpy as np

n_angles = 10
angles = np.linspace(0, np.pi, n_angles, dtype=np.float32)

ag = AcquisitionGeometry('cone', 'edo', pixel_num_h=20, pixel_num_v=2, angles=angles, 
                         dist_source_center = 312.2, 
                         dist_center_detector = 123. )
#ag = AcquisitionGeometry('parallel', 'edo', pixel_num_h=20, pixel_num_v=1, angles=angles )
ig = ImageGeometry(20,20)
astra_ig, astra_ag = convert_geometry_to_astra(ig, ag)
print (astra_ig)
print (astra_ag)
```
seems to work right.