### PR TITLE
Volume data dimension bug

### DIFF
--- a/Wrappers/Python/ccpi/astra/utils/convert_geometry_to_astra.py
+++ b/Wrappers/Python/ccpi/astra/utils/convert_geometry_to_astra.py
@@ -20,12 +20,12 @@ def convert_geometry_to_astra(volume_geometry, sinogram_geometry):
         raise ValueError('Number of pixels at detector on the vertical axis must be >= 0. Got {}'.format(vert))
     
     if dimension == '2D':
-        vol_geom = astra.create_vol_geom(volume_geometry.voxel_num_x, 
-                                         volume_geometry.voxel_num_y, 
-                                         volume_geometry.get_min_x(), 
-                                         volume_geometry.get_max_x(), 
+        vol_geom = astra.create_vol_geom(volume_geometry.voxel_num_y, 
+                                         volume_geometry.voxel_num_x, 
                                          volume_geometry.get_min_y(), 
-                                         volume_geometry.get_max_y())
+                                         volume_geometry.get_max_y(), 
+                                         volume_geometry.get_min_x(), 
+                                         volume_geometry.get_max_x())
         
         if sinogram_geometry.geom_type == 'parallel':
             proj_geom = astra.create_proj_geom('parallel',
@@ -43,13 +43,13 @@ def convert_geometry_to_astra(volume_geometry, sinogram_geometry):
             NotImplemented
             
     elif dimension == '3D':
-        vol_geom = astra.create_vol_geom(volume_geometry.voxel_num_x, 
-                                         volume_geometry.voxel_num_y, 
+        vol_geom = astra.create_vol_geom(volume_geometry.voxel_num_y, 
+                                         volume_geometry.voxel_num_x, 
                                          volume_geometry.voxel_num_z, 
-                                         volume_geometry.get_min_x(), 
-                                         volume_geometry.get_max_x(), 
                                          volume_geometry.get_min_y(), 
                                          volume_geometry.get_max_y(), 
+                                         volume_geometry.get_min_x(), 
+                                         volume_geometry.get_max_x(), 
                                          volume_geometry.get_min_z(), 
                                          volume_geometry.get_max_z())
         

--- a/Wrappers/Python/ccpi/astra/utils/convert_geometry_to_astra.py
+++ b/Wrappers/Python/ccpi/astra/utils/convert_geometry_to_astra.py
@@ -22,10 +22,10 @@ def convert_geometry_to_astra(volume_geometry, sinogram_geometry):
     if dimension == '2D':
         vol_geom = astra.create_vol_geom(volume_geometry.voxel_num_y, 
                                          volume_geometry.voxel_num_x, 
-                                         volume_geometry.get_min_y(), 
-                                         volume_geometry.get_max_y(), 
                                          volume_geometry.get_min_x(), 
-                                         volume_geometry.get_max_x())
+                                         volume_geometry.get_max_x(), 
+                                         volume_geometry.get_min_y(), 
+                                         volume_geometry.get_max_y())
         
         if sinogram_geometry.geom_type == 'parallel':
             proj_geom = astra.create_proj_geom('parallel',
@@ -46,10 +46,10 @@ def convert_geometry_to_astra(volume_geometry, sinogram_geometry):
         vol_geom = astra.create_vol_geom(volume_geometry.voxel_num_y, 
                                          volume_geometry.voxel_num_x, 
                                          volume_geometry.voxel_num_z, 
-                                         volume_geometry.get_min_y(), 
-                                         volume_geometry.get_max_y(), 
                                          volume_geometry.get_min_x(), 
                                          volume_geometry.get_max_x(), 
+                                         volume_geometry.get_min_y(), 
+                                         volume_geometry.get_max_y(), 
                                          volume_geometry.get_min_z(), 
                                          volume_geometry.get_max_z())
         


### PR DESCRIPTION
Bug fix in vol_geom astra det_row_count was being passed number_pixels_h instead of number_pixels_v, and the same for det_col_count.

With is fix we can now reconstruct non-square volumes.

