### PR TITLE
FBP

### DIFF
--- a/Wrappers/Python/ccpi/astra/processors/FBP.py
+++ b/Wrappers/Python/ccpi/astra/processors/FBP.py
@@ -26,6 +26,24 @@ from ccpi.astra.processors.FBP_Simple import FBP_Simple
 
 class FBP(DataProcessor):
 
+    '''FBP Filtered Back Projection is a reconstructor for 2D and 3D parallel and cone-beam geometries.
+    It is able to back-project circular trajectories with 2 PI anglar range and equally spaced anglular steps.
+
+    This uses the ram-lak filter
+    A CPU version is provided for simple 2D parallel-beam geometries only (offsets and rotations will be ignored)
+    
+    Input: Volume Geometry
+           Sinogram Geometry
+                             
+    Example:  fbp = FBP(ig, ag, device)
+              fbp.set_input(data)
+              reconstruction = fbp.get_ouput()
+                           
+    Output: ImageData                             
+
+    
+    '''
+    
     def __init__(self, volume_geometry, sinogram_geometry, device='gpu'): 
         
         super(FBP, self).__init__( volume_geometry=volume_geometry, sinogram_geometry=sinogram_geometry, device=device, processor = False)  
@@ -38,6 +56,10 @@ class FBP(DataProcessor):
             
         else:
             UserWarning("ASTRA back-projector running on CPU will not make use of enhanced geometry parameters")
+
+            if sinogram_geometry.geom_type == 'cone':
+                raise NotImplementedError("Cannot process cone-beam data without a GPU")
+
             if sinogram_geometry.dimension == '2D':
                 processor = FBP_Simple(volume_geometry, sinogram_geometry,  device='cpu') 
             else:

--- a/Wrappers/Python/ccpi/astra/processors/FBP.py
+++ b/Wrappers/Python/ccpi/astra/processors/FBP.py
@@ -1,0 +1,66 @@
+#========================================================================
+# Copyright 2019 Science Technology Facilities Council
+# Copyright 2019 University of Manchester
+#
+# This work is part of the Core Imaging Library developed by Science Technology
+# Facilities Council and University of Manchester
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#=========================================================================
+
+from ccpi.framework import DataProcessor
+from ccpi.astra.processors.FBP_Flexible import FBP_Flexible
+from ccpi.astra.processors.FDK_Flexible import FDK_Flexible
+from ccpi.astra.processors.FBP_Simple import FBP_Simple
+
+class FBP(DataProcessor):
+
+    def __init__(self, volume_geometry, sinogram_geometry, device='gpu'): 
+        
+        super(FBP, self).__init__( volume_geometry=volume_geometry, sinogram_geometry=sinogram_geometry, device=device, processor = False)  
+
+        if device is 'gpu':
+            if sinogram_geometry.geom_type == 'parallel':
+                processor = FBP_Flexible(volume_geometry, sinogram_geometry)
+            else:
+                processor = FDK_Flexible(volume_geometry, sinogram_geometry)
+            
+        else:
+            UserWarning("ASTRA back-projector running on CPU will not make use of enhanced geometry parameters")
+            if sinogram_geometry.dimension == '2D':
+                processor = FBP_Simple(volume_geometry, sinogram_geometry,  device='cpu') 
+            else:
+                raise NotImplementedError("Cannot process 3D data without a GPU")
+
+        if sinogram_geometry.channels > 1: 
+            raise NotImplementedError("Cannot process multi-channel data")
+            #processor_full = ChannelwiseProcessor(processor, self.sinogram_geometry.channels, dimension='prepend')
+            #self.processor = operator_full
+        
+        self.processor = processor
+
+    def set_input(self, dataset):       
+        return self.processor.set_input(dataset)
+
+    def get_input(self):       
+        return self.processor.get_input()
+
+    def get_output(self, out=None):       
+        return self.processor.get_output(out=None)
+
+    def check_input(self, dataset):       
+        return self.processor.check_input(dataset)
+        
+    def process(self, out=None):
+        return self.processor.process(out=None)

--- a/Wrappers/Python/ccpi/astra/processors/FBP.py
+++ b/Wrappers/Python/ccpi/astra/processors/FBP.py
@@ -46,8 +46,6 @@ class FBP(DataProcessor):
     
     def __init__(self, volume_geometry, sinogram_geometry, device='gpu'): 
         
-        super(FBP, self).__init__( volume_geometry=volume_geometry, sinogram_geometry=sinogram_geometry, device=device, processor = False)  
-
         if device is 'gpu':
             if sinogram_geometry.geom_type == 'parallel':
                 processor = FBP_Flexible(volume_geometry, sinogram_geometry)
@@ -70,7 +68,7 @@ class FBP(DataProcessor):
             #processor_full = ChannelwiseProcessor(processor, self.sinogram_geometry.channels, dimension='prepend')
             #self.processor = operator_full
         
-        self.processor = processor
+        super(FBP, self).__init__( volume_geometry=volume_geometry, sinogram_geometry=sinogram_geometry, device=device, processor=processor)  
 
     def set_input(self, dataset):       
         return self.processor.set_input(dataset)

--- a/Wrappers/Python/ccpi/astra/processors/FBP_Flexible.py
+++ b/Wrappers/Python/ccpi/astra/processors/FBP_Flexible.py
@@ -1,0 +1,106 @@
+from ccpi.framework import DataProcessor, ImageGeometry, AcquisitionGeometry, ImageData
+
+from ccpi.astra.utils import convert_geometry_to_astra_vec
+import astra
+import numpy
+
+class FBP_Flexible(DataProcessor):
+
+    '''FBP_Flexible Filtered Back Projection is a reconstructor for 2D and 3D parallel-beam geometries.
+    It is able to back-project circular trajectories with 2 PI anglar range and equally spaced anglular steps.
+
+    This uses the ram-lak filter
+    This is a GPU version only
+    
+    Input: Volume Geometry
+           Sinogram Geometry
+                             
+    Example:  fbp = FBP_Flexible(ig, ag)
+              fbp.set_input(sinogram)
+              reconstruction = fbp.get_ouput()
+                           
+    Output: ImageData                                 
+    '''
+
+    def __init__(self, volume_geometry, 
+                       sinogram_geometry): 
+        
+        super(FBP_Flexible, self).__init__( volume_geometry = volume_geometry,
+                                    sinogram_geometry = sinogram_geometry)   
+                          
+    def check_input(self, dataset):
+        
+        if self.sinogram_geometry.channels != 1:
+            raise ValueError("Expected input data to be single channel, got {0}"\
+                 .format(self.sinogram_geometry.channels))  
+
+        if self.sinogram_geometry.geom_type != 'parallel':
+            raise ValueError("Expected input data to be parallel beam geometry , got {0}"\
+                 .format(self.sinogram_geometry.geom_type))  
+
+        return True
+        
+    def set_projector(self, proj_id):
+        self.proj_id = proj_id
+        
+    def set_ImageGeometry(self, volume_geometry):
+        self.volume_geometry = volume_geometry
+        
+    def set_AcquisitionGeometry(self, sinogram_geometry):
+        self.sinogram_geometry = sinogram_geometry
+        
+    def process(self, out=None):
+           
+        # Get DATA
+        DATA = self.get_input()
+
+        sinogram_geometry = self.sinogram_geometry.copy()
+
+        #convert parallel geomerty to cone with large source to object
+        sinogram_geometry.config.system.update_reference_frame()
+
+        #reverse unitvector direction and extend to inf
+        cone_source = sinogram_geometry.config.system.ray.direction * -10000000
+        detector_position = sinogram_geometry.config.system.detector.position
+        detector_direction_row = sinogram_geometry.config.system.detector.direction_row
+
+        if self.sinogram_geometry.dimension == '2D':
+            sinogram_geometry_tmp = AcquisitionGeometry.create_Cone2D(cone_source, detector_position, detector_direction_row)
+        else:
+            detector_direction_col = sinogram_geometry.config.system.detector.direction_col
+            sinogram_geometry_tmp = AcquisitionGeometry.create_Cone3D(cone_source, detector_position, detector_direction_row, detector_direction_col)
+
+        sinogram_geometry.config.system = sinogram_geometry_tmp.config.system.copy()
+
+        vol_geom, proj_geom = convert_geometry_to_astra_vec(self.volume_geometry, sinogram_geometry)
+
+        pad = False
+        if len(DATA.shape) == 2:
+            #for 2D cases
+            pad = True
+            data_temp = numpy.expand_dims(DATA.as_array(),axis=0)
+        else:
+            data_temp = DATA.as_array()
+
+        rec_id = astra.data3d.create('-vol', vol_geom)
+        sinogram_id = astra.data3d.create('-sino', proj_geom, data_temp)
+        cfg = astra.astra_dict('FDK_CUDA')
+        cfg['ReconstructionDataId'] = rec_id
+        cfg['ProjectionDataId'] = sinogram_id
+        alg_id = astra.algorithm.create(cfg)
+        
+        astra.algorithm.run(alg_id)       
+        arr_out = astra.data3d.get(rec_id)
+
+        astra.data3d.delete(rec_id)
+        astra.data3d.delete(sinogram_id)                    
+        astra.algorithm.delete(alg_id)
+
+        if pad == True:
+            arr_out = numpy.squeeze(arr_out, axis=0)
+
+        if out is None:
+            out = ImageData(arr_out, deep_copy=False, geometry=self.volume_geometry.copy(), suppress_warning=True)
+            return out
+        else:
+            out.fill(arr_out)

--- a/Wrappers/Python/ccpi/astra/processors/FBP_Flexible.py
+++ b/Wrappers/Python/ccpi/astra/processors/FBP_Flexible.py
@@ -25,6 +25,8 @@ class FBP_Flexible(FDK_Flexible):
     def __init__(self, volume_geometry, 
                        sinogram_geometry): 
         
+        super(FBP_Flexible, self).__init__( volume_geometry = volume_geometry, sinogram_geometry = sinogram_geometry)
+
         #convert parallel geomerty to cone with large source to object
         sino_geom_cone = sinogram_geometry.copy()
         sino_geom_cone.config.system.update_reference_frame()
@@ -42,14 +44,8 @@ class FBP_Flexible(FDK_Flexible):
 
         sino_geom_cone.config.system = tmp.config.system.copy()
 
-        vol_geom_astra, proj_geom_astra = convert_geometry_to_astra_vec(volume_geometry, sino_geom_cone)
- 
-
-        super(FDK_Flexible, self).__init__( volume_geometry = volume_geometry,
-                                            sinogram_geometry = sinogram_geometry,
-                                            vol_geom_astra = vol_geom_astra,
-                                            proj_geom_astra = proj_geom_astra)
-                          
+        self.vol_geom_astra, self.proj_geom_astra = convert_geometry_to_astra_vec(volume_geometry, sino_geom_cone)
+                           
     def check_input(self, dataset):
         
         if self.sinogram_geometry.channels != 1:

--- a/Wrappers/Python/ccpi/astra/processors/FBP_Flexible.py
+++ b/Wrappers/Python/ccpi/astra/processors/FBP_Flexible.py
@@ -1,10 +1,10 @@
 from ccpi.framework import DataProcessor, ImageGeometry, AcquisitionGeometry, ImageData
-
+from ccpi.astra.processors.FDK_Flexible import FDK_Flexible
 from ccpi.astra.utils import convert_geometry_to_astra_vec
 import astra
 import numpy
 
-class FBP_Flexible(DataProcessor):
+class FBP_Flexible(FDK_Flexible):
 
     '''FBP_Flexible Filtered Back Projection is a reconstructor for 2D and 3D parallel-beam geometries.
     It is able to back-project circular trajectories with 2 PI anglar range and equally spaced anglular steps.
@@ -16,7 +16,7 @@ class FBP_Flexible(DataProcessor):
            Sinogram Geometry
                              
     Example:  fbp = FBP_Flexible(ig, ag)
-              fbp.set_input(sinogram)
+              fbp.set_input(data)
               reconstruction = fbp.get_ouput()
                            
     Output: ImageData                                 
@@ -25,8 +25,30 @@ class FBP_Flexible(DataProcessor):
     def __init__(self, volume_geometry, 
                        sinogram_geometry): 
         
-        super(FBP_Flexible, self).__init__( volume_geometry = volume_geometry,
-                                    sinogram_geometry = sinogram_geometry)   
+        #convert parallel geomerty to cone with large source to object
+        sino_geom_cone = sinogram_geometry.copy()
+        sino_geom_cone.config.system.update_reference_frame()
+
+        #reverse ray direction unit-vector direction and extend to inf
+        cone_source = sino_geom_cone.config.system.ray.direction * -10000000
+        detector_position = sino_geom_cone.config.system.detector.position
+        detector_direction_row = sino_geom_cone.config.system.detector.direction_row
+
+        if sinogram_geometry.dimension == '2D':
+            tmp = AcquisitionGeometry.create_Cone2D(cone_source, detector_position, detector_direction_row)
+        else:
+            detector_direction_col = sino_geom_cone.config.system.detector.direction_col
+            tmp = AcquisitionGeometry.create_Cone3D(cone_source, detector_position, detector_direction_row, detector_direction_col)
+
+        sino_geom_cone.config.system = tmp.config.system.copy()
+
+        vol_geom_astra, proj_geom_astra = convert_geometry_to_astra_vec(volume_geometry, sino_geom_cone)
+ 
+
+        super(FDK_Flexible, self).__init__( volume_geometry = volume_geometry,
+                                            sinogram_geometry = sinogram_geometry,
+                                            vol_geom_astra = vol_geom_astra,
+                                            proj_geom_astra = proj_geom_astra)
                           
     def check_input(self, dataset):
         
@@ -40,67 +62,3 @@ class FBP_Flexible(DataProcessor):
 
         return True
         
-    def set_projector(self, proj_id):
-        self.proj_id = proj_id
-        
-    def set_ImageGeometry(self, volume_geometry):
-        self.volume_geometry = volume_geometry
-        
-    def set_AcquisitionGeometry(self, sinogram_geometry):
-        self.sinogram_geometry = sinogram_geometry
-        
-    def process(self, out=None):
-           
-        # Get DATA
-        DATA = self.get_input()
-
-        sinogram_geometry = self.sinogram_geometry.copy()
-
-        #convert parallel geomerty to cone with large source to object
-        sinogram_geometry.config.system.update_reference_frame()
-
-        #reverse unitvector direction and extend to inf
-        cone_source = sinogram_geometry.config.system.ray.direction * -10000000
-        detector_position = sinogram_geometry.config.system.detector.position
-        detector_direction_row = sinogram_geometry.config.system.detector.direction_row
-
-        if self.sinogram_geometry.dimension == '2D':
-            sinogram_geometry_tmp = AcquisitionGeometry.create_Cone2D(cone_source, detector_position, detector_direction_row)
-        else:
-            detector_direction_col = sinogram_geometry.config.system.detector.direction_col
-            sinogram_geometry_tmp = AcquisitionGeometry.create_Cone3D(cone_source, detector_position, detector_direction_row, detector_direction_col)
-
-        sinogram_geometry.config.system = sinogram_geometry_tmp.config.system.copy()
-
-        vol_geom, proj_geom = convert_geometry_to_astra_vec(self.volume_geometry, sinogram_geometry)
-
-        pad = False
-        if len(DATA.shape) == 2:
-            #for 2D cases
-            pad = True
-            data_temp = numpy.expand_dims(DATA.as_array(),axis=0)
-        else:
-            data_temp = DATA.as_array()
-
-        rec_id = astra.data3d.create('-vol', vol_geom)
-        sinogram_id = astra.data3d.create('-sino', proj_geom, data_temp)
-        cfg = astra.astra_dict('FDK_CUDA')
-        cfg['ReconstructionDataId'] = rec_id
-        cfg['ProjectionDataId'] = sinogram_id
-        alg_id = astra.algorithm.create(cfg)
-        
-        astra.algorithm.run(alg_id)       
-        arr_out = astra.data3d.get(rec_id)
-
-        astra.data3d.delete(rec_id)
-        astra.data3d.delete(sinogram_id)                    
-        astra.algorithm.delete(alg_id)
-
-        if pad == True:
-            arr_out = numpy.squeeze(arr_out, axis=0)
-
-        if out is None:
-            out = ImageData(arr_out, deep_copy=False, geometry=self.volume_geometry.copy(), suppress_warning=True)
-            return out
-        else:
-            out.fill(arr_out)

--- a/Wrappers/Python/ccpi/astra/processors/FBP_Flexible.py
+++ b/Wrappers/Python/ccpi/astra/processors/FBP_Flexible.py
@@ -30,7 +30,7 @@ class FBP_Flexible(FDK_Flexible):
         sino_geom_cone.config.system.update_reference_frame()
 
         #reverse ray direction unit-vector direction and extend to inf
-        cone_source = sino_geom_cone.config.system.ray.direction * -10000000
+        cone_source = -sino_geom_cone.config.system.ray.direction * sino_geom_cone.config.panel.pixel_size[1] * sino_geom_cone.config.panel.num_pixels[1] * 1e6
         detector_position = sino_geom_cone.config.system.detector.position
         detector_direction_row = sino_geom_cone.config.system.detector.direction_row
 

--- a/Wrappers/Python/ccpi/astra/processors/FBP_Simple.py
+++ b/Wrappers/Python/ccpi/astra/processors/FBP_Simple.py
@@ -4,9 +4,9 @@ import astra
 import numpy as np
 import warnings
 
-class FBP(DataProcessor):
+class FBP_Simple(DataProcessor):
     
-    '''Filtered Back Projection is a reconstructor
+    '''FBP_Simple Filtered Back Projection is a reconstructor
     
     Input: Volume Geometry
            Sinogram Geometry
@@ -51,7 +51,7 @@ class FBP(DataProcessor):
             if sinogram_geometry.geom_type=='parallel':
                 
                 # By default, we select GPU device
-                super(FBP, self).__init__(volume_geometry = volume_geometry, 
+                super(FBP_Simple, self).__init__(volume_geometry = volume_geometry, 
                                      sinogram_geometry = sinogram_geometry,
                                      device = 'gpu', proj_id = None,
                                      vol_geom2D = None, proj_geom2D = None,
@@ -81,7 +81,7 @@ class FBP(DataProcessor):
             elif sinogram_geometry.geom_type=='cone':
                  
                 # For 3D cone we do not need  ASTRA proj_id
-                super(FBP, self).__init__(volume_geometry = volume_geometry, 
+                super(FBP_Simple, self).__init__(volume_geometry = volume_geometry, 
                      sinogram_geometry = sinogram_geometry,
                      device = 'gpu',
                      filter_type = 'ram-lak')   
@@ -93,7 +93,7 @@ class FBP(DataProcessor):
             
             
             # Setup for 2D case
-            super(FBP, self).__init__(volume_geometry = volume_geometry, 
+            super(FBP_Simple, self).__init__(volume_geometry = volume_geometry, 
                                       sinogram_geometry = sinogram_geometry,
                                       device = device, proj_id = None,
                                       filter_type = filter_type)
@@ -344,8 +344,4 @@ class FBP(DataProcessor):
                     astra.algorithm.delete(alg_id)
                         
                     return IM                        
-        
-        
-
-
- 
+                    

--- a/Wrappers/Python/ccpi/astra/processors/FDK_Flexible.py
+++ b/Wrappers/Python/ccpi/astra/processors/FDK_Flexible.py
@@ -16,7 +16,7 @@ class FDK_Flexible(DataProcessor):
            Sinogram Geometry
                              
     Example:  fdk = FDK_Flexible(ig, ag)
-              fdk.set_input(sinogram)
+              fdk.set_input(data)
               reconstruction = fdk.get_ouput()
                            
     Output: ImageData                             
@@ -27,8 +27,15 @@ class FDK_Flexible(DataProcessor):
     def __init__(self, volume_geometry, 
                        sinogram_geometry): 
         
+        vol_geom_astra, proj_geom_astra = convert_geometry_to_astra_vec(volume_geometry, sinogram_geometry)
+ 
+
         super(FDK_Flexible, self).__init__( volume_geometry = volume_geometry,
-                                        sinogram_geometry = sinogram_geometry)   
+                                        sinogram_geometry = sinogram_geometry,
+                                        vol_geom_astra = vol_geom_astra,
+                                        proj_geom_astra = proj_geom_astra)
+
+
                           
     def check_input(self, dataset):
         
@@ -42,20 +49,11 @@ class FDK_Flexible(DataProcessor):
 
         return True
         
-    def set_projector(self, proj_id):
-        self.proj_id = proj_id
-        
-    def set_ImageGeometry(self, volume_geometry):
-        self.volume_geometry = volume_geometry
-        
-    def set_AcquisitionGeometry(self, sinogram_geometry):
-        self.sinogram_geometry = sinogram_geometry
-        
+
     def process(self, out=None):
            
         # Get DATA
         DATA = self.get_input()
-        vol_geom, proj_geom = convert_geometry_to_astra_vec(self.volume_geometry, self.sinogram_geometry)
 
         pad = False
         if len(DATA.shape) == 2:
@@ -66,8 +64,8 @@ class FDK_Flexible(DataProcessor):
             data_temp = DATA.as_array()
 
 
-        rec_id = astra.data3d.create('-vol', vol_geom)
-        sinogram_id = astra.data3d.create('-sino', proj_geom, data_temp)
+        rec_id = astra.data3d.create('-vol', self.vol_geom_astra)
+        sinogram_id = astra.data3d.create('-sino', self.proj_geom_astra, data_temp)
         cfg = astra.astra_dict('FDK_CUDA')
         cfg['ReconstructionDataId'] = rec_id
         cfg['ProjectionDataId'] = sinogram_id

--- a/Wrappers/Python/ccpi/astra/processors/FDK_Flexible.py
+++ b/Wrappers/Python/ccpi/astra/processors/FDK_Flexible.py
@@ -4,9 +4,9 @@ import astra
 import numpy
 import warnings
 
-class FDK(DataProcessor):
+class FDK_Flexible(DataProcessor):
 
-    '''FDK Filtered Back Projection is a reconstructor for 2D and 3D cone-beam geometries.
+    '''FDK_Flexible Filtered Back Projection is a reconstructor for 2D and 3D cone-beam geometries.
     It is able to back-project circular trajectories with 2 PI anglar range and equally spaced anglular steps.
 
     This uses the ram-lak filter
@@ -15,9 +15,9 @@ class FDK(DataProcessor):
     Input: Volume Geometry
            Sinogram Geometry
                              
-    Example:  FDK(ig, ag)
-              FDK.set_input(sinogram)
-              reconstruction = FDK.get_ouput()
+    Example:  fdk = FDK_Flexible(ig, ag)
+              fdk.set_input(sinogram)
+              reconstruction = fdk.get_ouput()
                            
     Output: ImageData                             
 
@@ -27,7 +27,7 @@ class FDK(DataProcessor):
     def __init__(self, volume_geometry, 
                        sinogram_geometry): 
         
-        super(FDK, self).__init__( volume_geometry = volume_geometry,
+        super(FDK_Flexible, self).__init__( volume_geometry = volume_geometry,
                                         sinogram_geometry = sinogram_geometry)   
                           
     def check_input(self, dataset):

--- a/Wrappers/Python/ccpi/astra/processors/__init__.py
+++ b/Wrappers/Python/ccpi/astra/processors/__init__.py
@@ -6,6 +6,5 @@ from .AstraBackProjectorMC import AstraBackProjectorMC
 from .AstraForwardProjector3D import AstraForwardProjector3D
 from .AstraBackProjector3D import AstraBackProjector3D
 from .FBP import FBP
-from .FDK import FDK
 from .AstraForwardProjectorVec import AstraForwardProjectorVec
 from .AstraBackProjectorVec import AstraBackProjectorVec

--- a/Wrappers/Python/test/test_FBP.py
+++ b/Wrappers/Python/test/test_FBP.py
@@ -98,7 +98,7 @@ class TestProcessors(unittest.TestCase):
 
         #2D cone
         #foward project
-        ag = self.ag_cone.subset(vertical=self.cs_ind, force=True)
+        ag = self.ag_cone.subset(vertical='centre')
         ig = ag.get_ImageGeometry()
         A = AstraOperator(ig, ag, device='gpu')
         fp_2D = A.direct(self.golden_data.subset(vertical=self.cs_ind, force=True))
@@ -121,7 +121,7 @@ class TestProcessors(unittest.TestCase):
 
 
         #2D parallel
-        ag = self.ag_parallel.subset(vertical=self.cs_ind, force=True)
+        ag = self.ag_parallel.subset(vertical='centre')
         ig = ag.get_ImageGeometry()
         A = AstraOperator(ig, ag, device='gpu')
         fp_2D = A.direct(self.golden_data.subset(vertical=self.cs_ind, force=True))
@@ -144,7 +144,7 @@ class TestProcessors(unittest.TestCase):
 
     def test_FBPcpu(self):
         #2D parallel
-        ag = self.ag_parallel.subset(vertical=self.cs_ind, force=True)
+        ag = self.ag_parallel.subset(vertical='centre')
         ig = ag.get_ImageGeometry()
         A = AstraOperator(ig, ag, device='cpu')
         fp_2D = A.direct(self.golden_data.subset(vertical=self.cs_ind, force=True))

--- a/Wrappers/Python/test/test_FBP.py
+++ b/Wrappers/Python/test/test_FBP.py
@@ -98,15 +98,15 @@ class TestProcessors(unittest.TestCase):
 
         #2D cone
         #foward project
-        ag = self.ag_cone.subset(vertical=self.cs_ind)
+        ag = self.ag_cone.subset(vertical=self.cs_ind, force=True)
         ig = ag.get_ImageGeometry()
         A = AstraOperator(ig, ag, device='gpu')
-        fp_2D = A.direct(self.golden_data.subset(vertical=self.cs_ind))
+        fp_2D = A.direct(self.golden_data.subset(vertical=self.cs_ind, force=True))
 
         fbp = FBP(ig, ag, 'gpu')
         fbp.set_input(fp_2D)
         fbp_2D_cone = fbp.get_output()
-        np.testing.assert_allclose(fbp_2D_cone.as_array(),self.golden_data.subset(vertical=self.cs_ind).as_array(),atol=1)
+        np.testing.assert_allclose(fbp_2D_cone.as_array(),self.golden_data.subset(vertical=self.cs_ind, force=True).as_array(),atol=1)
 
         #3D cone
         ag = self.ag_cone
@@ -121,15 +121,15 @@ class TestProcessors(unittest.TestCase):
 
 
         #2D parallel
-        ag = self.ag_parallel.subset(vertical=self.cs_ind)
+        ag = self.ag_parallel.subset(vertical=self.cs_ind, force=True)
         ig = ag.get_ImageGeometry()
         A = AstraOperator(ig, ag, device='gpu')
-        fp_2D = A.direct(self.golden_data.subset(vertical=self.cs_ind))
+        fp_2D = A.direct(self.golden_data.subset(vertical=self.cs_ind, force=True))
 
         fbp = FBP(ig, ag, 'gpu')
         fbp.set_input(fp_2D)
         fbp_2D_parallel = fbp.get_output()
-        np.testing.assert_allclose(fbp_2D_parallel.as_array(),self.golden_data.subset(vertical=self.cs_ind).as_array(), atol=1)
+        np.testing.assert_allclose(fbp_2D_parallel.as_array(),self.golden_data.subset(vertical=self.cs_ind, force=True).as_array(), atol=1)
 
         #3D parallel
         ag = self.ag_parallel
@@ -144,12 +144,12 @@ class TestProcessors(unittest.TestCase):
 
     def test_FBPcpu(self):
         #2D parallel
-        ag = self.ag_parallel.subset(vertical=self.cs_ind)
+        ag = self.ag_parallel.subset(vertical=self.cs_ind, force=True)
         ig = ag.get_ImageGeometry()
         A = AstraOperator(ig, ag, device='cpu')
-        fp_2D = A.direct(self.golden_data.subset(vertical=self.cs_ind))
+        fp_2D = A.direct(self.golden_data.subset(vertical=self.cs_ind, force=True))
 
         fbp = FBP(ig, ag, 'cpu')
         fbp.set_input(fp_2D)
         fbp_2D_parallel = fbp.get_output()
-        np.testing.assert_allclose(fbp_2D_parallel.as_array(),self.golden_data.subset(vertical=self.cs_ind).as_array(),atol=1)
+        np.testing.assert_allclose(fbp_2D_parallel.as_array(),self.golden_data.subset(vertical=self.cs_ind, force=True).as_array(),atol=1)

--- a/Wrappers/Python/test/test_FBP.py
+++ b/Wrappers/Python/test/test_FBP.py
@@ -1,0 +1,155 @@
+# -*- coding: utf-8 -*-
+#  CCP in Tomographic Imaging (CCPi) Core Imaging Library (CIL).
+
+#   Copyright 2017 UKRI-STFC
+#   Copyright 2017 University of Manchester
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+from ccpi.framework import ImageGeometry, AcquisitionGeometry
+from ccpi.framework import ImageData, AcquisitionData
+
+from ccpi.astra.operators import AstraOperator
+from ccpi.astra.processors import FBP
+
+from ccpi.utilities.display import plotter2D
+
+
+import unittest
+import numpy as np
+
+import astra
+
+use_cuda = True
+try:
+    astra.test_CUDA()
+except RuntimeError as re:
+    print (re)
+    use_cuda = False
+except:
+    use_cuda = False
+
+
+class TestProcessors(unittest.TestCase):
+    def setUp(self): 
+        #%% Setup Geometry
+        voxel_num_xy = 255
+        voxel_num_z = 15
+        self.cs_ind = (voxel_num_z-1)//2
+
+
+        src_to_obj = 500
+        src_to_det = src_to_obj
+
+        pix_size = 0.2
+        det_pix_x = voxel_num_xy
+        det_pix_y = voxel_num_z
+
+        num_projections = 180
+        angles = np.linspace(0, np.pi, num=num_projections, endpoint=False)
+
+        self.ag_cone = AcquisitionGeometry.create_Cone3D([0,-src_to_obj,0],[0,src_to_det-src_to_obj,0])\
+                                     .set_angles(angles, angle_unit='radian')\
+                                     .set_panel((det_pix_x,det_pix_y), (pix_size,pix_size))\
+                                     .set_labels(['vertical','angle','horizontal'])
+
+        self.ag_parallel = AcquisitionGeometry.create_Parallel3D()\
+                                     .set_angles(angles, angle_unit='radian')\
+                                     .set_panel((det_pix_x,det_pix_y), (pix_size,pix_size))\
+                                     .set_labels(['vertical','angle','horizontal'])
+
+        self.ig_3D = self.ag_parallel.get_ImageGeometry()
+
+        #%% Create phantom
+        kernel_size = voxel_num_xy
+        kernel_radius = (kernel_size - 1) // 2
+        y, x = np.ogrid[-kernel_radius:kernel_radius+1, -kernel_radius:kernel_radius+1]
+
+        circle1 = [5,0,0] #r,x,y
+        dist1 = ((x - circle1[1])**2 + (y - circle1[2])**2)**0.5
+
+        circle2 = [5,100,0] #r,x,y
+        dist2 = ((x - circle2[1])**2 + (y - circle2[2])**2)**0.5
+
+        circle3 = [25,0,100] #r,x,y
+        dist3 = ((x - circle3[1])**2 + (y - circle3[2])**2)**0.5
+
+        mask1 =(dist1 - circle1[0]).clip(0,1) 
+        mask2 =(dist2 - circle2[0]).clip(0,1) 
+        mask3 =(dist3 - circle3[0]).clip(0,1) 
+        phantom = 1 - np.logical_and(np.logical_and(mask1, mask2),mask3)
+
+        self.golden_data = self.ig_3D.allocate(0)
+        for i in range(4):
+            self.golden_data.fill(array=phantom, vertical=7+i)
+
+    @unittest.skipIf(not use_cuda, "Astra not built with CUDA")
+    def test_FBPgpu(self):
+
+        #2D cone
+        #foward project
+        ag = self.ag_cone.subset(vertical=self.cs_ind)
+        ig = ag.get_ImageGeometry()
+        A = AstraOperator(ig, ag, device='gpu')
+        fp_2D = A.direct(self.golden_data.subset(vertical=self.cs_ind))
+
+        fbp = FBP(ig, ag, 'gpu')
+        fbp.set_input(fp_2D)
+        fbp_2D_cone = fbp.get_output()
+        np.testing.assert_allclose(fbp_2D_cone.as_array(),self.golden_data.subset(vertical=self.cs_ind).as_array(),atol=1)
+
+        #3D cone
+        ag = self.ag_cone
+        ig = ag.get_ImageGeometry()
+        A = AstraOperator(ig, ag, device='gpu')
+        fp_3D = A.direct(self.golden_data)
+
+        fbp = FBP(ig, ag, 'gpu')
+        fbp.set_input(fp_3D)
+        fbp_3D_cone = fbp.get_output()
+        np.testing.assert_allclose(fbp_3D_cone.as_array(),self.golden_data.as_array(),atol=1)
+
+
+        #2D parallel
+        ag = self.ag_parallel.subset(vertical=self.cs_ind)
+        ig = ag.get_ImageGeometry()
+        A = AstraOperator(ig, ag, device='gpu')
+        fp_2D = A.direct(self.golden_data.subset(vertical=self.cs_ind))
+
+        fbp = FBP(ig, ag, 'gpu')
+        fbp.set_input(fp_2D)
+        fbp_2D_parallel = fbp.get_output()
+        np.testing.assert_allclose(fbp_2D_parallel.as_array(),self.golden_data.subset(vertical=self.cs_ind).as_array(), atol=1)
+
+        #3D parallel
+        ag = self.ag_parallel
+        ig = ag.get_ImageGeometry()
+        A = AstraOperator(ig, ag, device='gpu')
+        fp_3D = A.direct(self.golden_data)
+
+        fbp = FBP(ig, ag, 'gpu')
+        fbp.set_input(fp_3D)
+        fbp_3D_parallel = fbp.get_output()
+        np.testing.assert_allclose(fbp_3D_parallel.as_array(),self.golden_data.as_array(),atol=1)
+
+    def test_FBPcpu(self):
+        #2D parallel
+        ag = self.ag_parallel.subset(vertical=self.cs_ind)
+        ig = ag.get_ImageGeometry()
+        A = AstraOperator(ig, ag, device='cpu')
+        fp_2D = A.direct(self.golden_data.subset(vertical=self.cs_ind))
+
+        fbp = FBP(ig, ag, 'cpu')
+        fbp.set_input(fp_2D)
+        fbp_2D_parallel = fbp.get_output()
+        np.testing.assert_allclose(fbp_2D_parallel.as_array(),self.golden_data.subset(vertical=self.cs_ind).as_array(),atol=1)


### PR DESCRIPTION
Update all FBP GPU based algorithms to use new geometry

Create `FBP_Flexible` DataProcessor
Rename `FDK` to `FDK_Flexible` DataProcessor
Rename `FBP` to `FBP_Simple` DataProcessor

Create `FBP` DataProcessor that selects correct sub-class.

for GPU data will use either FDK_Flexible or FBP_Simple
for cpu will use FBP_Simple 2D versions


ToDo: Multi-channel version
